### PR TITLE
 도메인 설계 1 : 기본 회원 정보와 개인 스키마 저장 테이블

### DIFF
--- a/src/main/java/com/backend/testdata/domain/SchemaFieldEntity.java
+++ b/src/main/java/com/backend/testdata/domain/SchemaFieldEntity.java
@@ -1,0 +1,24 @@
+package com.backend.testdata.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class SchemaFieldEntity {
+    
+
+    private String fieldName;
+
+    private String mockDataType;
+
+    private Integer fieldOrder;
+
+    private Integer blankPercent;
+
+    private String typeOptionJson;
+
+    private String forceValue;
+
+
+}

--- a/src/main/java/com/backend/testdata/domain/TableSchemaEntity.java
+++ b/src/main/java/com/backend/testdata/domain/TableSchemaEntity.java
@@ -1,0 +1,24 @@
+package com.backend.testdata.domain;
+
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+
+@ToString
+@Getter
+public class TableSchemaEntity {
+
+
+    private String schemaName;
+
+    private String userId;
+
+    private LocalDateTime exportedAt;
+
+
+
+
+}


### PR DESCRIPTION
이 작업은 기본적인 테이블 스키마, 스키마 필드에 필요한 도메인 데이터를 설계함

This closes #3 