### PR TITLE
 자료형 도메인 설계

### DIFF
--- a/src/main/java/com/backend/testdata/domain/SchemaFieldEntity.java
+++ b/src/main/java/com/backend/testdata/domain/SchemaFieldEntity.java
@@ -1,5 +1,6 @@
 package com.backend.testdata.domain;
 
+import com.backend.testdata.domain.constants.MockDataType;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -10,7 +11,7 @@ public class SchemaFieldEntity {
 
     private String fieldName;
 
-    private String mockDataType;
+    private MockDataType mockDataType;
 
     private Integer fieldOrder;
 

--- a/src/main/java/com/backend/testdata/domain/constants/MockDataType.java
+++ b/src/main/java/com/backend/testdata/domain/constants/MockDataType.java
@@ -1,0 +1,46 @@
+package com.backend.testdata.domain.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@RequiredArgsConstructor
+public enum MockDataType {
+
+    STRING(Set.of("minLength", "maxLength", "pattern"), null),
+    NUMBER(Set.of("min", "max", "decimal"), null),
+    BOOLEAN(Set.of(), null),
+    DATETIME(Set.of("from", "to"), null),
+    ENUM(Set.of("elements"), null),
+
+    SENTENCE(Set.of("minSentences", "maxSentences"), STRING),
+    PARAGRAPH(Set.of("minParagraphs", "maxParagraphs"), STRING),
+    UUID(Set.of(), STRING),
+    EMAIL(Set.of(), STRING),
+    CAR(Set.of(), STRING),
+    ROW_NUMBER(Set.of("start, step"), NUMBER),
+    NAME(Set.of(), STRING),
+
+    ;
+
+
+    private final Set<String> options;
+    private final MockDataType baseType;
+
+    public boolean isBaseType() {
+        return this.baseType == null;
+    }
+
+    public MockDataTypeObject toObject(){
+        return new MockDataTypeObject(
+                this.name(),
+                this.options,
+                this.baseType == null ? null : this.baseType.name()
+        );
+    }
+
+
+    public record MockDataTypeObject(String name, Set<String> options, String baseType) {}
+}

--- a/src/test/java/com/backend/testdata/domain/constants/MockDataTypeTest.java
+++ b/src/test/java/com/backend/testdata/domain/constants/MockDataTypeTest.java
@@ -1,0 +1,39 @@
+package com.backend.testdata.domain.constants;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[Domain] 테스트 데이터 자료형 테스트")
+class MockDataTypeTest {
+
+
+    @DisplayName("자료형이 주어지면, 해당 원소의 이름을 리턴한다.")
+    @Test
+    void givenMockDataType_whenReading_thenReturnEnumElementName() {
+        //given
+        MockDataType mockDataType = MockDataType.STRING;
+
+        //when
+        String elementName = mockDataType.toString();
+
+        //then
+        Assertions.assertThat(MockDataType.STRING.name()).isEqualTo(elementName);
+    }
+
+
+    @DisplayName("자료형이 주어지면 해당 원소의 데이터를 DTO 로 랩핑해서 리턴한다.")
+    @Test
+    void givenMockDataType_whenReading_thenReturnEnumElementDto() {
+        //given
+        MockDataType mockDataType = MockDataType.STRING;
+
+        //when
+        MockDataType.MockDataTypeObject expectedObject = mockDataType.toObject();
+
+        //then
+        Assertions.assertThat(expectedObject.toString()).contains("name", "options", "baseType");
+    }
+
+
+}


### PR DESCRIPTION
이 작업은 가짜 데이터 자료형 도메인을 데이터베이스에서 저장관리 하지 않고 애플리케이션의 enum을 이용해 좀 더 유용하게 관리, 그리고 
프론트쪽으로 넘겨 enum 데이터를 사용 할 수 있도록 (직렬화 할 수 있도록) 고려 후에 테스트까지 간단하게 진행함

This closes #6 