### PR TITLE
Repository 테스트 코드 작성

### DIFF
--- a/src/main/java/com/backend/testdata/domain/TableSchemaEntity.java
+++ b/src/main/java/com/backend/testdata/domain/TableSchemaEntity.java
@@ -2,10 +2,8 @@ package com.backend.testdata.domain;
 
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -22,7 +20,13 @@ import java.util.Set;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString(exclude = "schemaFields", callSuper = true)
 @Getter
-@Table(name = "\"table_schema\"")
+@Table(name = "\"table_schema\"", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "schema_name"})
+},
+        indexes = {
+                @Index(columnList = "created_at"),
+                @Index(columnList = "modified_at")
+})
 @Entity
 public class TableSchemaEntity extends AuditingField {
 
@@ -30,6 +34,7 @@ public class TableSchemaEntity extends AuditingField {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Column(name = "schema_name", nullable = false)
     private String schemaName;
     @Column(name = "user_id", nullable = false)
@@ -38,6 +43,7 @@ public class TableSchemaEntity extends AuditingField {
     @Column(name = "exported_at")
     private LocalDateTime exportedAt;
 
+    @OrderBy("fieldOrder asc")
     @OneToMany(mappedBy = "tableSchema", cascade = CascadeType.ALL, orphanRemoval = true)
     private final Set<SchemaFieldEntity> schemaFields = new LinkedHashSet<>();
 

--- a/src/main/java/com/backend/testdata/repository/TableSchemaEntityRepository.java
+++ b/src/main/java/com/backend/testdata/repository/TableSchemaEntityRepository.java
@@ -1,7 +1,17 @@
 package com.backend.testdata.repository;
 
 import com.backend.testdata.domain.TableSchemaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TableSchemaEntityRepository extends JpaRepository<TableSchemaEntity, Long> {
+
+    Page<TableSchemaEntity> findAllByUserId(String userId, Pageable pageable);
+
+    Optional<TableSchemaEntity> findByUserIdAndSchemaName(String userId, String schemaName);
+
+    void deleteByUserIdAndSchemaName(String userId, String schemaName);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@ logging:
   level:
     com.backend.testdata: debug
     org.springframework.web.servlet: debug
+    org.hibernate.orm.jdbc.bind: trace
+    org.springframework.test.context.transaction.TransactionContext: debug
+
+
 
 
 
@@ -25,9 +29,11 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
   sql:
     init:
       mode: always
+
 
 ---
 
@@ -37,11 +43,9 @@ spring:
       on-profile: test
   datasource:
     url: jdbc:h2:mem:test.db;MODE=MySQL;DATABASE_TO_LOWER=TRUE
-    username:
-    password:
+    username: lsh
+    password: password
     driver-class-name: org.h2.Driver
-  jpa:
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
+
+
+

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,32 @@
+insert into table_schema (id, schema_name, user_id, exported_at, created_at, created_by, modified_at, modified_by)
+values (1, 'test_schema1', 'devJohn', null, now(), 'shlee', now(), 'shlee');
+
+
+alter table table_schema
+    auto_increment = 2;
+
+insert into schema_field (table_schema_id, field_name, mock_data_type, field_order, blank_percent, type_option_json,
+                          force_value,
+                          created_at, created_by, modified_at, modified_by)
+values (1, 'id', 'ROW_NUMBER', 1, 0, '{"start" : 1, "step" : 1}', null, now(), 'shlee', now(), 'shlee'),
+       (1, 'age', 'NUMBER', 3, 0, '{"min" : 1, "max" : 30, "decimal" : 0}', null, now(), 'shlee', now(), 'shlee'),
+       (1, 'name', 'STRING', 2, 0, '{"minLength" : 1, "maxLength" : 10}', null, now(), 'shlee', now(), 'shlee'),
+       (1, 'car', 'STRING', 4, 0, '{"minLength" : 1, "maxLength" : 10}', null, now(), 'shlee', now(), 'shlee');
+
+
+insert into mock_data(mock_data_type, mock_data_value)
+values ('name', '김민준'),
+       ('name', '이서윤'),
+       ('name', '박지윤'),
+       ('name', '박지후'),
+       ('name', '김서진'),
+       ('name', '김세진'),
+       ('name', '강예진'),
+       ('name', '김혜은'),
+       ('name', '이서빈'),
+       ('car', '제네시스 G70'),
+       ('car', '제네시스 G80'),
+       ('car', '벤츠 S 클래스'),
+       ('car', '벤츠 E 클래스'),
+       ('car', '기아 K5'),
+       ('car', '기아 K3');

--- a/src/test/java/com/backend/testdata/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/backend/testdata/repository/JpaRepositoryTest.java
@@ -1,0 +1,202 @@
+package com.backend.testdata.repository;
+
+
+import com.backend.testdata.domain.MockDataEntity;
+import com.backend.testdata.domain.SchemaFieldEntity;
+import com.backend.testdata.domain.TableSchemaEntity;
+import com.backend.testdata.domain.constants.MockDataType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+@Import(JpaRepositoryTest.TestJpaConfiguration.class)
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 실제 DB 참조
+@DisplayName("[Repository] JPA 테스트")
+@DataJpaTest
+class JpaRepositoryTest {
+
+
+    @Autowired
+    private MockDataEntityRepository mockDataEntityRepository;
+    @Autowired
+    private SchemaFieldEntityRepository schemaFieldEntityRepository;
+    @Autowired
+    private TableSchemaEntityRepository tableSchemaEntityRepository;
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    private static final String TEST_AUDITOR = "hoonseung";
+
+
+    @DisplayName("SELECT")
+    @Test
+    void select_test() {
+        //given
+
+
+        //when
+        var mockDataEntities = mockDataEntityRepository.findAll();
+        var schemaFieldEntities = schemaFieldEntityRepository.findAll();
+        var tableSchemaEntities = tableSchemaEntityRepository.findAll();
+
+        //then
+        assertThat(mockDataEntities).hasSizeGreaterThan(1);
+        assertThat(schemaFieldEntities)
+                .hasSize(4)
+                .first()
+                .extracting("tableSchema")
+                .isEqualTo(tableSchemaEntities.getFirst());
+
+        assertThat(tableSchemaEntities)
+                .hasSize(1)
+                .first()
+                .hasFieldOrPropertyWithValue("schemaName", "test_schema1")
+                .hasFieldOrPropertyWithValue("userId", "devJohn")
+                .extracting("schemaFields", InstanceOfAssertFactories.COLLECTION)
+                .hasSize(4);
+    }
+
+
+    @DisplayName("INSERT 후 반환된 데이터에 대한 검증 (연관관계)")
+    @Test
+    void insert_test() {
+        //given
+        var tableSchema = TableSchemaEntity.of("test_schema2", "devJohn");
+        tableSchema.addAllSchemaFieldAndSetRelation(List.of(
+                SchemaFieldEntity.of("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
+                SchemaFieldEntity.of("age", MockDataType.ROW_NUMBER, 2, 0, null, null),
+                SchemaFieldEntity.of("name", MockDataType.NAME, 3, 0, null, null)
+        ));
+
+        //when
+        var tableSchemaPs = tableSchemaEntityRepository.save(tableSchema);
+
+        //then
+        testEntityManager.clear();
+        assertThat(tableSchemaPs.getId()).isNotNull();
+        assertThat(tableSchemaEntityRepository.findById(tableSchemaPs.getId()).get())
+                .hasFieldOrPropertyWithValue("schemaName", "test_schema2")
+                .hasFieldOrPropertyWithValue("userId", "devJohn")
+                .hasFieldOrPropertyWithValue("createdBy", TEST_AUDITOR)
+                .hasFieldOrProperty("createdAt")
+                .hasFieldOrProperty("modifiedAt")
+                .extracting("schemaFields", InstanceOfAssertFactories.COLLECTION)
+                .hasSize(3)
+                .extracting("fieldOrder", Integer.class)
+                .containsExactly(1, 2, 3);
+
+        assertThat(tableSchemaPs.getCreatedAt()).isEqualTo(tableSchemaPs.getModifiedAt());
+    }
+
+    @DisplayName("UPDATE")
+    @Test
+    void update_test() {
+        //given
+        var tableSchemaPs = tableSchemaEntityRepository.findAll().getFirst();
+        tableSchemaPs.setSchemaName("test_modified");
+        tableSchemaPs.clearSchemaFields();
+        var schemaField = SchemaFieldEntity.of("id", MockDataType.ROW_NUMBER, 1, 0,
+                json(Map.of("min", 1, "max", 30)), null);
+        tableSchemaPs.addSchemaFieldAndSetRelation(schemaField);
+        //when
+        var tableSchemaPsUpdated = tableSchemaEntityRepository.saveAndFlush(tableSchemaPs);
+
+        //then
+        assertThat(tableSchemaPsUpdated)
+                .hasFieldOrPropertyWithValue("schemaName", "test_modified")
+                .hasFieldOrPropertyWithValue("createdBy", "shlee")
+                .hasFieldOrPropertyWithValue("modifiedBy", TEST_AUDITOR)
+                .extracting("schemaFields", InstanceOfAssertFactories.COLLECTION)
+                .hasSize(1);
+
+        assertThat(tableSchemaPs.getModifiedAt()).isAfter(tableSchemaPsUpdated.getCreatedAt());
+    }
+
+
+    @DisplayName("DELETE")
+    @Test
+    void delete_test() {
+        //given
+        var tableSchemaPs = tableSchemaEntityRepository.findAll().getFirst();
+
+        //when
+        tableSchemaEntityRepository.delete(tableSchemaPs);
+
+        //then
+        assertThat(tableSchemaEntityRepository.count()).isZero();
+        assertThat(schemaFieldEntityRepository.count()).isZero();
+    }
+
+
+    @DisplayName("UK 제약조건 동작 검증")
+    @Test
+    void uk_test() {
+        //given
+        var mockData1 = MockDataEntity.of(MockDataType.CAR, "제네시스 G70");
+        var mockData2 = MockDataEntity.of(MockDataType.CAR, "제네시스 G70");
+
+        //when
+        Throwable ex = catchThrowable(() -> mockDataEntityRepository.saveAll(List.of(mockData1, mockData2)));
+
+
+        //then
+        assertThat(ex)
+                .isInstanceOf(DataIntegrityViolationException.class)
+                .hasCauseInstanceOf(ConstraintViolationException.class)
+                .hasRootCauseInstanceOf(SQLIntegrityConstraintViolationException.class)
+                .rootCause()
+                .hasMessageContaining("Unique index or primary key violation");
+    }
+
+
+    private String json(Object object) {
+        try {
+            return mapper.writeValueAsString(object);
+        } catch (JsonProcessingException jpe) {
+            throw new RuntimeException("테스트에서 Json 파싱 중 에러 발생", jpe);
+        }
+    }
+
+    @EnableJpaAuditing
+    @TestConfiguration
+    static class TestJpaConfiguration {
+
+        @Bean
+        public AuditorAware<String> auditorAware() {
+            return () -> Optional.of(TEST_AUDITOR);
+        }
+
+        @Bean
+        public ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+    }
+
+}

--- a/src/test/java/com/backend/testdata/repository/TableSchemaEntityRepositoryTest.java
+++ b/src/test/java/com/backend/testdata/repository/TableSchemaEntityRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.backend.testdata.repository;
+
+import com.backend.testdata.domain.TableSchemaEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("[Repository] 테이블 스키마 쿼리 메소드 테스트")
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class TableSchemaEntityRepositoryTest {
+
+    @Autowired
+    private TableSchemaEntityRepository sut;
+    @Autowired
+    private TableSchemaEntityRepository tableSchemaEntityRepository;
+
+
+    @DisplayName("사용자별 테이블 스키마 목록 조회하면 페이징된 테이블 스키마를 반환한다.")
+    @Test
+    void if_givenUserId_whenRetrieveAllTableSchemas_thenReturnsPagedEntities() {
+        //given
+        var userId = "devJohn";
+
+        //when
+        Page<TableSchemaEntity> tableSchemaPsList = sut.findAllByUserId(userId, Pageable.ofSize(5));
+
+        //then
+        assertThat(tableSchemaPsList).isNotEmpty();
+        assertThat(tableSchemaPsList.getContent())
+                .hasSize(1)
+                .extracting("userId", String.class)
+                .containsExactly(userId);
+        assertThat(tableSchemaPsList.getPageable())
+                .hasFieldOrPropertyWithValue("pageSize", 5)
+                .hasFieldOrPropertyWithValue("pageNumber", 0);
+    }
+
+
+    @DisplayName("사용자의 테이블 스키마 이름으로 단일 테이블 스키마 조회하면 Optional 타입의 테이블 스키마를 반환한다.")
+    @Test
+    void if_givenUserIdAndSchemaName_whenRetrieveOneTableSchema_thenReturnsOptionalEntities() {
+        //given
+        var userId = "devJohn";
+        var schemaName = "test_schema1";
+
+        //when
+        Optional<TableSchemaEntity> tableSchemaPs = tableSchemaEntityRepository.findByUserIdAndSchemaName(userId, schemaName);
+
+        //then
+        assertThat(tableSchemaPs).isNotEmpty();
+        assertThat(tableSchemaPs.get().getUserId()).isEqualTo(userId);
+        assertThat(tableSchemaPs.get().getSchemaName()).isEqualTo(schemaName);
+    }
+
+
+    @DisplayName("사용자의 테이블 스키마 이름입력하면 테이블 스키마를 삭제한다.")
+    @Test
+    void if_givenUserIdAndSchemaName_thenDeleteTableSchemaAndDoNothing() {
+        //given
+        var userId = "devJohn";
+        var schemaName = "test_schema1";
+
+        //when
+        sut.deleteByUserIdAndSchemaName(userId, schemaName);
+
+        //then
+        assertThat(tableSchemaEntityRepository.findByUserIdAndSchemaName(userId, schemaName)).isEmpty();
+    }
+}


### PR DESCRIPTION
JPA DDL Auto 기능과 수동 DML 스크립트 적용 뒤
기본 JPA 동작과 TableSchemaEntity Repository 에 정의한 쿼리메서드 동작을 테스트 하였음 그리고 TableSchemaEntity의 schemaFields에 OrderBy 어노테이션을 추가하여 조회 시 정렬될 수 있도록 구성 하였으며 유니크 제약 조건, 인덱스 추가까지 진행함

This closes #20 