### PR TITLE
API 구현과 DTO 코드 작성 1

### DIFF
--- a/src/main/java/com/backend/testdata/dto/MockDataDto.java
+++ b/src/main/java/com/backend/testdata/dto/MockDataDto.java
@@ -1,0 +1,19 @@
+package com.backend.testdata.dto;
+
+import com.backend.testdata.domain.MockDataEntity;
+import com.backend.testdata.domain.constants.MockDataType;
+
+public record MockDataDto(
+        Long id,
+        MockDataType mockDataType,
+        String mockDataValue
+) {
+
+    public static MockDataDto toDto(MockDataEntity entity) {
+        return new MockDataDto(
+                entity.getId(),
+                entity.getMockDataType(),
+                entity.getMockDataValue()
+        );
+    }
+}

--- a/src/main/java/com/backend/testdata/dto/SchemaFieldDto.java
+++ b/src/main/java/com/backend/testdata/dto/SchemaFieldDto.java
@@ -1,0 +1,57 @@
+package com.backend.testdata.dto;
+
+import com.backend.testdata.domain.SchemaFieldEntity;
+import com.backend.testdata.domain.constants.MockDataType;
+
+import java.time.LocalDateTime;
+
+
+public record SchemaFieldDto(
+        Long id,
+        String fieldName,
+        MockDataType mockDataType,
+        Integer fieldOrder,
+        Integer blankPercent,
+        String typeOptionJson,
+        String forceValue,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy) {
+
+
+    public static SchemaFieldDto of(Long id, String fieldName, MockDataType mockDataType, Integer fieldOrder, Integer blankPercent, String typeOptionJson, String forceValue, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new SchemaFieldDto(id, fieldName, mockDataType, fieldOrder, blankPercent, typeOptionJson, forceValue, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static SchemaFieldDto of(String fieldName, MockDataType mockDataType, Integer fieldOrder, Integer blankPercent, String typeOptionJson, String forceValue) {
+        return new SchemaFieldDto(null, fieldName, mockDataType, fieldOrder, blankPercent, typeOptionJson, forceValue, null, null, null, null);
+    }
+
+    public static SchemaFieldDto toDto(SchemaFieldEntity entity) {
+        return new SchemaFieldDto(
+                entity.getId(),
+                entity.getFieldName(),
+                entity.getMockDataType(),
+                entity.getFieldOrder(),
+                entity.getBlankPercent(),
+                entity.getTypeOptionJson(),
+                entity.getForceValue(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+
+    public SchemaFieldEntity createEntity() {
+        return SchemaFieldEntity.of(
+                this.fieldName,
+                this.mockDataType,
+                this.fieldOrder,
+                this.blankPercent,
+                this.typeOptionJson,
+                this.forceValue);
+    }
+}

--- a/src/main/java/com/backend/testdata/dto/TableSchemaDto.java
+++ b/src/main/java/com/backend/testdata/dto/TableSchemaDto.java
@@ -1,0 +1,60 @@
+package com.backend.testdata.dto;
+
+import com.backend.testdata.domain.TableSchemaEntity;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+public record TableSchemaDto(
+        Long id,
+        String schemaName,
+        String userId,
+        LocalDateTime exportedAt,
+        Set<SchemaFieldDto> schemaFields,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+
+) {
+
+    public static TableSchemaDto of(Long id, String schemaName, String userId, LocalDateTime exportedAt, Set<SchemaFieldDto> schemaFields, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new TableSchemaDto(id, schemaName, userId, exportedAt, schemaFields, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static TableSchemaDto of(String schemaName, String userId, LocalDateTime exportedAt, Set<SchemaFieldDto> schemaFields) {
+        return new TableSchemaDto(null, schemaName, userId, exportedAt, schemaFields, null, null, null, null);
+    }
+
+
+    public static TableSchemaDto toDto(TableSchemaEntity entity) {
+        return new TableSchemaDto(
+                entity.getId(),
+                entity.getSchemaName(),
+                entity.getUserId(),
+                entity.getExportedAt(),
+                entity.getSchemaFields().stream()
+                        .map(SchemaFieldDto::toDto)
+                        .collect(Collectors.toUnmodifiableSet()),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+
+    public TableSchemaEntity createEntity() {
+        TableSchemaEntity tableSchemaEntity = TableSchemaEntity.of(this.schemaName, this.userId);
+        tableSchemaEntity.addAllSchemaFieldAndSetRelation(this.schemaFields.stream()
+                        .map(SchemaFieldDto::createEntity)
+                        .toList()
+        );
+
+        return tableSchemaEntity;
+    }
+
+
+}

--- a/src/main/java/com/backend/testdata/dto/request/SchemaFieldRequest.java
+++ b/src/main/java/com/backend/testdata/dto/request/SchemaFieldRequest.java
@@ -1,0 +1,25 @@
+package com.backend.testdata.dto.request;
+
+import com.backend.testdata.domain.constants.MockDataType;
+import com.backend.testdata.dto.SchemaFieldDto;
+
+public record SchemaFieldRequest(
+        String fieldName,
+        MockDataType mockDataType,
+        Integer fieldOrder,
+        Integer blankPercent,
+        String typeOptionJson,
+        String forceValue
+) {
+
+    public SchemaFieldDto toDto() {
+        return SchemaFieldDto.of(
+                this.fieldName,
+                this.mockDataType,
+                this.fieldOrder,
+                this.blankPercent,
+                this.typeOptionJson,
+                this.forceValue
+        );
+    }
+}

--- a/src/main/java/com/backend/testdata/dto/request/TableSchemaRequest.java
+++ b/src/main/java/com/backend/testdata/dto/request/TableSchemaRequest.java
@@ -1,0 +1,24 @@
+package com.backend.testdata.dto.request;
+
+import com.backend.testdata.dto.TableSchemaDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record TableSchemaRequest(
+        String schemaName,
+        String userId,
+        List<SchemaFieldRequest> schemaFields
+) {
+
+    public TableSchemaDto toDto() {
+        return TableSchemaDto.of(
+                this.schemaName,
+                this.userId,
+                null,
+                this.schemaFields.stream()
+                        .map(SchemaFieldRequest::toDto)
+                        .collect(Collectors.toUnmodifiableSet())
+        );
+    }
+}

--- a/src/main/java/com/backend/testdata/dto/response/SchemaFieldResponse.java
+++ b/src/main/java/com/backend/testdata/dto/response/SchemaFieldResponse.java
@@ -1,0 +1,26 @@
+package com.backend.testdata.dto.response;
+
+import com.backend.testdata.domain.constants.MockDataType;
+import com.backend.testdata.dto.SchemaFieldDto;
+
+public record SchemaFieldResponse(
+        String fieldName,
+        MockDataType mockDataType,
+        Integer fieldOrder,
+        Integer blankPercent,
+        String typeOptionJson,
+        String forceValue
+) {
+
+
+    public static SchemaFieldResponse toResponse(SchemaFieldDto dto) {
+        return new SchemaFieldResponse(
+                dto.fieldName(),
+                dto.mockDataType(),
+                dto.fieldOrder(),
+                dto.blankPercent(),
+                dto.typeOptionJson(),
+                dto.forceValue()
+        );
+    }
+}

--- a/src/main/java/com/backend/testdata/dto/response/SimpleTableSchemaResponse.java
+++ b/src/main/java/com/backend/testdata/dto/response/SimpleTableSchemaResponse.java
@@ -1,0 +1,16 @@
+package com.backend.testdata.dto.response;
+
+import com.backend.testdata.dto.TableSchemaDto;
+
+public record SimpleTableSchemaResponse(
+        String userId,
+        String schemaName
+) {
+
+    public static SimpleTableSchemaResponse toSimpleResponse(TableSchemaDto dto) {
+        return new SimpleTableSchemaResponse(
+                dto.userId(),
+                dto.schemaName()
+        );
+    }
+}

--- a/src/main/java/com/backend/testdata/dto/response/TableSchemaResponse.java
+++ b/src/main/java/com/backend/testdata/dto/response/TableSchemaResponse.java
@@ -1,0 +1,23 @@
+package com.backend.testdata.dto.response;
+
+import com.backend.testdata.dto.TableSchemaDto;
+
+import java.util.List;
+
+public record TableSchemaResponse(
+        String userId,
+        String schemaName,
+        List<SchemaFieldResponse> schemaFields
+) {
+
+    public static TableSchemaResponse toResponse(TableSchemaDto dto) {
+        return new TableSchemaResponse(
+                dto.userId(),
+                dto.schemaName(),
+                dto.schemaFields().stream()
+                        .map(SchemaFieldResponse::toResponse)
+                        .toList()
+        );
+
+    }
+}

--- a/src/main/java/com/backend/testdata/dto/response/TableSchemaResponse.java
+++ b/src/main/java/com/backend/testdata/dto/response/TableSchemaResponse.java
@@ -5,15 +5,15 @@ import com.backend.testdata.dto.TableSchemaDto;
 import java.util.List;
 
 public record TableSchemaResponse(
-        String userId,
         String schemaName,
+        String userId,
         List<SchemaFieldResponse> schemaFields
 ) {
 
     public static TableSchemaResponse toResponse(TableSchemaDto dto) {
         return new TableSchemaResponse(
-                dto.userId(),
                 dto.schemaName(),
+                dto.userId(),
                 dto.schemaFields().stream()
                         .map(SchemaFieldResponse::toResponse)
                         .toList()

--- a/src/test/java/com/backend/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/com/backend/testdata/controller/TableSchemaControllerTest.java
@@ -1,7 +1,10 @@
 package com.backend.testdata.controller;
 
 import com.backend.testdata.configuration.SecurityConfiguration;
-import org.junit.jupiter.api.Disabled;
+import com.backend.testdata.domain.constants.MockDataType;
+import com.backend.testdata.util.FormDataEncoder;
+import com.backend.testdata.util.SchemaFieldRequestWithMock;
+import com.backend.testdata.util.TableSchemaRequestWithMock;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,18 +15,21 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Disabled("해당 테스트는 #24 이슈에서 진행되었음, 구현은 진행하지않고 테스트로 기초 스펙만 정의함")
+//@Disabled("해당 테스트는 #24 이슈에서 진행되었음, 구현은 진행하지않고 테스트로 기초 스펙만 정의함")
 @DisplayName("[Controller] 테이블 스키마")
-@Import(SecurityConfiguration.class)
+@Import({SecurityConfiguration.class, FormDataEncoder.class})
 @AutoConfigureMockMvc
 @WebMvcTest
 record TableSchemaControllerTest(
-        @Autowired MockMvc mvc
+        @Autowired MockMvc mvc,
+        @Autowired FormDataEncoder encoder
 ) {
 
     @DisplayName("[GET] 테이블 스키마 페이지를 요청하면 테이블 스키마 뷰 (정상) 를 반환한다.")
@@ -43,10 +49,18 @@ record TableSchemaControllerTest(
     @Test
     void whenCreatedOrUpdatedTableSchema_ThenRedirectionToTableSchemaPage() throws Exception {
         //given
+        var request = TableSchemaRequestWithMock.create("test_schema", "홍길동",
+                List.of(
+                        SchemaFieldRequestWithMock.create("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
+                        SchemaFieldRequestWithMock.create("name", MockDataType.NAME, 2, 0, null, null),
+                        SchemaFieldRequestWithMock.create("age", MockDataType.NUMBER, 3, 0, null, null)
+                ));
+
+
 
         //when & then
         mvc.perform(post("/table-schema")
-                        .queryParam("data", "sample") //TODO 수정 필요
+                        .content(encoder.encode(request))
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                         .with(csrf()))
                 .andExpect(status().is3xxRedirection())

--- a/src/test/java/com/backend/testdata/util/FormDataEncoder.java
+++ b/src/test/java/com/backend/testdata/util/FormDataEncoder.java
@@ -1,0 +1,46 @@
+package com.backend.testdata.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+
+@TestComponent
+public class FormDataEncoder {
+
+    @Autowired
+    private ObjectMapper mapper;
+
+
+    public String encode(Object obj) {
+        return encode(obj, true);
+    }
+
+    public String encode(Object obj, boolean applyUrlEncoding) {
+        Map<String, Object> fieldMap = mapper.convertValue(obj, new TypeReference<>() {
+        });
+
+        UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
+
+        fieldMap.forEach((key, value) -> addToBuilder(builder, key, value));
+
+        return applyUrlEncoding ? builder.build().encode().getQuery() : builder.build().getQuery();
+    }
+
+    private void addToBuilder(UriComponentsBuilder builder, String key, Object value) {
+        switch (value) {
+            case Map<?, ?> map ->
+                    map.forEach((subKey, subValue) -> addToBuilder(builder, key + "." + subKey, subValue));
+            case List<?> list ->
+                    IntStream.range(0, list.size()).forEach(i -> addToBuilder(builder, key + "[" + i + "]", list.get(i)));
+            case null -> {}
+            default -> builder.queryParam(key, value.toString());
+        }
+    }
+}

--- a/src/test/java/com/backend/testdata/util/SchemaFieldRequestWithMock.java
+++ b/src/test/java/com/backend/testdata/util/SchemaFieldRequestWithMock.java
@@ -1,0 +1,18 @@
+package com.backend.testdata.util;
+
+import com.backend.testdata.domain.constants.MockDataType;
+import com.backend.testdata.dto.request.SchemaFieldRequest;
+
+public class SchemaFieldRequestWithMock {
+
+    public static SchemaFieldRequest create(String fieldName, MockDataType mockDataType, Integer fieldOrder, Integer blankPercent, String typeOptionJson, String forceValue) {
+        return new SchemaFieldRequest(
+                fieldName,
+                mockDataType,
+                fieldOrder,
+                blankPercent,
+                typeOptionJson,
+                forceValue
+        );
+    }
+}

--- a/src/test/java/com/backend/testdata/util/TableSchemaRequestWithMock.java
+++ b/src/test/java/com/backend/testdata/util/TableSchemaRequestWithMock.java
@@ -1,0 +1,17 @@
+package com.backend.testdata.util;
+
+import com.backend.testdata.dto.request.SchemaFieldRequest;
+import com.backend.testdata.dto.request.TableSchemaRequest;
+
+import java.util.List;
+
+public class TableSchemaRequestWithMock {
+
+    public static TableSchemaRequest create(String schemaName, String userId, List<SchemaFieldRequest> schemaFields) {
+        return new TableSchemaRequest(
+                schemaName,
+                userId,
+                schemaFields
+        );
+    }
+}


### PR DESCRIPTION
이 작업은 record 키워드를 사용하여  사용자 요청, 응답. 애플리케이션 계층간 사용될 DTO 작성,
객체를 폼 데이터 형식으로 직렬화를 도와주는 객체를 추가하였음

This closes #28 