### PR TITLE
로직 구현 : 개인 스키마 수정

### DIFF
--- a/src/main/java/com/backend/testdata/domain/TableSchemaEntity.java
+++ b/src/main/java/com/backend/testdata/domain/TableSchemaEntity.java
@@ -1,15 +1,30 @@
 package com.backend.testdata.domain;
 
 
-import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.BatchSize;
-
+import com.backend.testdata.dto.SchemaFieldDto;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * 식별자 {@link #userId} 로 특정한 회원이 소유한다.
@@ -21,86 +36,111 @@ import java.util.Set;
 @ToString(exclude = "schemaFields", callSuper = true)
 @Getter
 @Table(name = "\"table_schema\"", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"user_id", "schema_name"})
+    @UniqueConstraint(columnNames = {"user_id", "schema_name"})
 },
-        indexes = {
-                @Index(columnList = "created_at"),
-                @Index(columnList = "modified_at")
-})
+    indexes = {
+        @Index(columnList = "created_at"),
+        @Index(columnList = "modified_at")
+    })
 @Entity
 public class TableSchemaEntity extends AuditingField {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Setter
-    @Column(name = "schema_name", nullable = false)
-    private String schemaName;
-    @Column(name = "user_id", nullable = false)
-    private String userId;
+  @Setter
+  @Column(name = "schema_name", nullable = false)
+  private String schemaName;
+  @Column(name = "user_id", nullable = false)
+  private String userId;
 
-    @Column(name = "exported_at")
-    private LocalDateTime exportedAt;
+  @Column(name = "exported_at")
+  private LocalDateTime exportedAt;
 
-    @OrderBy("fieldOrder asc")
-    @OneToMany(mappedBy = "tableSchema", cascade = CascadeType.ALL, orphanRemoval = true)
-    private final Set<SchemaFieldEntity> schemaFields = new LinkedHashSet<>();
+  @OrderBy("fieldOrder asc")
+  @OneToMany(mappedBy = "tableSchema", cascade = CascadeType.ALL, orphanRemoval = true)
+  private final Set<SchemaFieldEntity> schemaFields = new LinkedHashSet<>();
 
 
-    private TableSchemaEntity(String schemaName, String userId) {
-        this.schemaName = schemaName;
-        this.userId = userId;
+  private TableSchemaEntity(String schemaName, String userId) {
+    this.schemaName = schemaName;
+    this.userId = userId;
+  }
+
+  public static TableSchemaEntity of(String schemaName, String userId) {
+    return new TableSchemaEntity(
+        schemaName,
+        userId
+    );
+  }
+
+
+  public void addSchemaFieldAndSetRelation(SchemaFieldEntity schemaField) {
+    this.schemaFields.add(schemaField);
+    schemaField.setRelationEntity(this);
+  }
+
+  public void addAllSchemaFieldAndSetRelation(Collection<SchemaFieldEntity> schemaFields) {
+    schemaFields.forEach(this::addSchemaFieldAndSetRelation);
+  }
+
+
+  public void updateTableSchema(String schemaName, String userId, LocalDateTime exportedAt,
+      Collection<SchemaFieldDto> schemaFields) {
+    if (!StringUtils.hasText(schemaName)) {
+      this.schemaName = schemaName;
+    }
+    if (!StringUtils.hasText(userId)) {
+      this.userId = userId;
     }
 
-    public static TableSchemaEntity of(String schemaName, String userId) {
-        return new TableSchemaEntity(
-                schemaName,
-                userId
-        );
+    this.exportedAt = exportedAt;
+
+    if (!CollectionUtils.isEmpty(schemaFields)) {
+      clearSchemaFields();
+      addAllSchemaFieldAndSetRelation(
+          schemaFields.stream().map(SchemaFieldDto::createEntity).toList());
     }
 
+  }
 
-    public void addSchemaFieldAndSetRelation(SchemaFieldEntity schemaField) {
-        this.schemaFields.add(schemaField);
-        schemaField.setRelationEntity(this);
+  public void clearSchemaFields() {
+    this.schemaFields.clear();
+  }
+
+  public boolean isExported() {
+    return this.exportedAt != null;
+  }
+
+  public void markExported() {
+    this.exportedAt = LocalDateTime.now();
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
-
-    public void addAllSchemaFieldAndSetRelation(Collection<SchemaFieldEntity> schemaFields) {
-        schemaFields.forEach(this::addSchemaFieldAndSetRelation);
+    if (!(o instanceof TableSchemaEntity that)) {
+      return false;
     }
-
-    public void clearSchemaFields() {
-        this.schemaFields.clear();
+    if (this.getId() == null || that.getId() == null) {
+      return Objects.equals(this.getSchemaName(), that.getSchemaName())
+          && Objects.equals(this.getUserId(), that.getUserId())
+          && Objects.equals(this.getExportedAt(), that.getExportedAt())
+          && Objects.equals(this.getSchemaFields(), that.getSchemaFields());
     }
+    return Objects.equals(this.getId(), that.getId());
+  }
 
-    public boolean isExported() {
-        return this.exportedAt != null;
-    }
-
-    public void markExported() {
-        this.exportedAt = LocalDateTime.now();
-    }
-
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof TableSchemaEntity that)) return false;
-        if (this.getId() == null || that.getId() == null) {
-            return Objects.equals(this.getSchemaName(), that.getSchemaName())
-                    && Objects.equals(this.getUserId(), that.getUserId())
-                    && Objects.equals(this.getExportedAt(), that.getExportedAt())
-                    && Objects.equals(this.getSchemaFields(), that.getSchemaFields());
-        }
-        return Objects.equals(this.getId(), that.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return this.getId() == null ? Objects.hash(getSchemaName(), getUserId(), getExportedAt(), getSchemaFields())
-                : Objects.hash(getId());
-    }
+  @Override
+  public int hashCode() {
+    return this.getId() == null ? Objects.hash(getSchemaName(), getUserId(), getExportedAt(),
+        getSchemaFields())
+        : Objects.hash(getId());
+  }
 
 
 }

--- a/src/main/java/com/backend/testdata/dto/TableSchemaDto.java
+++ b/src/main/java/com/backend/testdata/dto/TableSchemaDto.java
@@ -1,60 +1,72 @@
 package com.backend.testdata.dto;
 
 import com.backend.testdata.domain.TableSchemaEntity;
-
 import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 
 public record TableSchemaDto(
-        Long id,
-        String schemaName,
-        String userId,
-        LocalDateTime exportedAt,
-        Set<SchemaFieldDto> schemaFields,
-        LocalDateTime createdAt,
-        String createdBy,
-        LocalDateTime modifiedAt,
-        String modifiedBy
+    Long id,
+    String schemaName,
+    String userId,
+    LocalDateTime exportedAt,
+    Set<SchemaFieldDto> schemaFields,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime modifiedAt,
+    String modifiedBy
 
 ) {
 
-    public static TableSchemaDto of(Long id, String schemaName, String userId, LocalDateTime exportedAt, Set<SchemaFieldDto> schemaFields, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new TableSchemaDto(id, schemaName, userId, exportedAt, schemaFields, createdAt, createdBy, modifiedAt, modifiedBy);
-    }
+  public static TableSchemaDto of(Long id, String schemaName, String userId,
+      LocalDateTime exportedAt, Set<SchemaFieldDto> schemaFields, LocalDateTime createdAt,
+      String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+    return new TableSchemaDto(id, schemaName, userId, exportedAt, schemaFields, createdAt,
+        createdBy, modifiedAt, modifiedBy);
+  }
 
-    public static TableSchemaDto of(String schemaName, String userId, LocalDateTime exportedAt, Set<SchemaFieldDto> schemaFields) {
-        return new TableSchemaDto(null, schemaName, userId, exportedAt, schemaFields, null, null, null, null);
-    }
-
-
-    public static TableSchemaDto toDto(TableSchemaEntity entity) {
-        return new TableSchemaDto(
-                entity.getId(),
-                entity.getSchemaName(),
-                entity.getUserId(),
-                entity.getExportedAt(),
-                entity.getSchemaFields().stream()
-                        .map(SchemaFieldDto::toDto)
-                        .collect(Collectors.toUnmodifiableSet()),
-                entity.getCreatedAt(),
-                entity.getCreatedBy(),
-                entity.getModifiedAt(),
-                entity.getModifiedBy()
-        );
-    }
+  public static TableSchemaDto of(String schemaName, String userId, LocalDateTime exportedAt,
+      Set<SchemaFieldDto> schemaFields) {
+    return new TableSchemaDto(null, schemaName, userId, exportedAt, schemaFields, null, null, null,
+        null);
+  }
 
 
-    public TableSchemaEntity createEntity() {
-        TableSchemaEntity tableSchemaEntity = TableSchemaEntity.of(this.schemaName, this.userId);
-        tableSchemaEntity.addAllSchemaFieldAndSetRelation(this.schemaFields.stream()
-                        .map(SchemaFieldDto::createEntity)
-                        .toList()
-        );
+  public static TableSchemaDto toDto(TableSchemaEntity entity) {
+    return new TableSchemaDto(
+        entity.getId(),
+        entity.getSchemaName(),
+        entity.getUserId(),
+        entity.getExportedAt(),
+        entity.getSchemaFields().stream()
+            .map(SchemaFieldDto::toDto)
+            .collect(Collectors.toUnmodifiableSet()),
+        entity.getCreatedAt(),
+        entity.getCreatedBy(),
+        entity.getModifiedAt(),
+        entity.getModifiedBy()
+    );
+  }
 
-        return tableSchemaEntity;
-    }
+
+  public TableSchemaEntity createEntity() {
+    TableSchemaEntity tableSchemaEntity = TableSchemaEntity.of(this.schemaName, this.userId);
+    tableSchemaEntity.addAllSchemaFieldAndSetRelation(this.schemaFields.stream()
+        .map(SchemaFieldDto::createEntity)
+        .toList()
+    );
+
+    return tableSchemaEntity;
+  }
 
 
+  public void updateEntity(TableSchemaEntity entity) {
+    entity.updateTableSchema(
+        this.schemaName,
+        this.userId,
+        this.exportedAt,
+        this.schemaFields
+    );
+  }
 }

--- a/src/main/java/com/backend/testdata/service/TableSchemaService.java
+++ b/src/main/java/com/backend/testdata/service/TableSchemaService.java
@@ -38,8 +38,11 @@ public class TableSchemaService {
   }
 
   @Transactional
-  public void saveMySchema(TableSchemaDto tableSchemaDto) {
-    tableSchemaEntityRepository.save(tableSchemaDto.createEntity());
+  public void upsertMySchema(TableSchemaDto tableSchemaDto) {
+    tableSchemaEntityRepository.findByUserIdAndSchemaName(tableSchemaDto.userId(),
+            tableSchemaDto.schemaName())
+        .ifPresentOrElse(tableSchemaDto::updateEntity,
+            () -> tableSchemaEntityRepository.save(tableSchemaDto.createEntity()));
   }
 
 

--- a/src/test/java/com/backend/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/com/backend/testdata/controller/TableSchemaControllerTest.java
@@ -9,11 +9,11 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlTemplate;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
@@ -47,146 +47,147 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(TableSchemaController.class)
 class TableSchemaControllerTest {
 
-  @Autowired
-  private MockMvc mvc;
-  @Autowired
-  private FormDataEncoder encoder;
-  @Autowired
-  private ObjectMapper mapper;
-  @MockBean
-  private TableSchemaService tableSchemaService;
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private FormDataEncoder encoder;
+    @Autowired
+    private ObjectMapper mapper;
+    @MockBean
+    private TableSchemaService tableSchemaService;
 
 
-  @DisplayName("[GET] 테이블 스키마 페이지를 요청하면 테이블 스키마 뷰 (정상) 를 반환한다.")
-  @Test
-  void whenEnteredTableSchemaPage_ThenShowTableSchemaView() throws Exception {
-    //given
+    @DisplayName("[GET] 테이블 스키마 페이지를 요청하면 테이블 스키마 뷰 (정상) 를 반환한다.")
+    @Test
+    void whenEnteredTableSchemaPage_ThenShowTableSchemaView() throws Exception {
+        //given
 
-    //when & then
-    mvc.perform(get("/table-schema"))
-        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-        .andExpect(status().isOk())
-        .andExpect(model().attributeExists("tableSchema"))
-        .andExpect(model().attributeExists("mockDataTypes"))
-        .andExpect(model().attributeExists("fileTypes"))
-        .andExpect(view().name("table-schema"));
+        //when & then
+        mvc.perform(get("/table-schema"))
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+            .andExpect(status().isOk())
+            .andExpect(model().attributeExists("tableSchema"))
+            .andExpect(model().attributeExists("mockDataTypes"))
+            .andExpect(model().attributeExists("fileTypes"))
+            .andExpect(view().name("table-schema"));
 
-    then(tableSchemaService).shouldHaveNoInteractions();
-  }
+        then(tableSchemaService).shouldHaveNoInteractions();
+    }
 
-  @DisplayName("[GET] 인증 사용자 스키마 테이블 목록에서 스키마 이름을 누르면 테이블 스키마 뷰 (정상) 를 반환한다.")
-  @Test
-  void givenParam_whenEnteredTableSchemaPage_ThenShowTableSchemaView() throws Exception {
-    //given
-    var githubUser = new GithubUser("test_id", "test_name", "test@email.com");
-    var schemaName = "test_schema";
-    given(tableSchemaService.loadMyTableSchema(githubUser.id(), schemaName)).willReturn(
-        TableSchemaDto.of(schemaName, githubUser.id(), null, Set.of()));
+    @DisplayName("[GET] 인증 사용자 스키마 테이블 목록에서 스키마 이름을 누르면 테이블 스키마 뷰 (정상) 를 반환한다.")
+    @Test
+    void givenParam_whenEnteredTableSchemaPage_ThenShowTableSchemaView() throws Exception {
+        //given
+        var githubUser = new GithubUser("test_id", "test_name", "test@email.com");
+        var schemaName = "test_schema";
+        given(tableSchemaService.loadMyTableSchema(githubUser.id(), schemaName)).willReturn(
+            TableSchemaDto.of(schemaName, githubUser.id(), null, Set.of()));
 
-    //when & then
-    mvc.perform(get("/table-schema").queryParam("schemaName", schemaName)
-            .with(oauth2Login().oauth2User(githubUser)))
-        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-        .andExpect(status().isOk())
-        .andExpect(model().attributeExists("tableSchema"))
-        .andExpect(model().attributeExists("mockDataTypes"))
-        .andExpect(model().attributeExists("fileTypes"))
-        .andExpect(view().name("table-schema"))
-        .andExpect(content().string(containsString(schemaName))); // html 내 포함 여부
-  }
-
-
-  @DisplayName("[POST] 테이블 스키마 생성, 변경을 요청하면 정상적으로 수행 후 테이블 스키마 페이지로 리다이렉션한다.")
-  @Test
-  void whenCreatedOrUpdatedTableSchema_ThenRedirectionToTableSchemaPage() throws Exception {
-    //given
-    var githubUser = new GithubUser("test_id", "test_name", "test@email.com");
-    var request = TableSchemaRequestWithMock.create("test_schema",
-        List.of(
-            SchemaFieldRequestWithMock.create("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
-            SchemaFieldRequestWithMock.create("name", MockDataType.NAME, 2, 0, null, null),
-            SchemaFieldRequestWithMock.create("age", MockDataType.NUMBER, 3, 0, null, null)
-        ));
-
-    willDoNothing().given(tableSchemaService).saveMySchema(request.toDto(githubUser.id()));
-
-    //when & then
-    mvc.perform(post("/table-schema")
-            .content(encoder.encode(request))
-            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-            .with(csrf()).with(oauth2Login().oauth2User(githubUser)))
-        .andExpect(status().is3xxRedirection())
-        .andExpect(flash().attributeExists("tableSchemaRequest"))
-        .andExpect(redirectedUrl("/table-schema"));
-
-    then(tableSchemaService).should().saveMySchema(request.toDto(githubUser.id()));
-  }
+        //when & then
+        mvc.perform(get("/table-schema").queryParam("schemaName", schemaName)
+                .with(oauth2Login().oauth2User(githubUser)))
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+            .andExpect(status().isOk())
+            .andExpect(model().attributeExists("tableSchema"))
+            .andExpect(model().attributeExists("mockDataTypes"))
+            .andExpect(model().attributeExists("fileTypes"))
+            .andExpect(view().name("table-schema"))
+            .andExpect(content().string(containsString(schemaName))); // html 내 포함 여부
+    }
 
 
-  @DisplayName("[GET] 회원의 테이블 스키마 목록 페이지를 요청하면 회원의 테이블 스키마 목록 뷰 (정상) 를 반환한다.")
-  @Test
-  void whenAuthUserEnteredAllTableSchemaPage_ThenShowAllTableSchemaView() throws Exception {
-    //given
-    var githubUser = new GithubUser("test_id", "test_name", "test@email.com");
-    //when
-    given(tableSchemaService.loadTableSchemas("test_id")).willReturn(List.of());
-    mvc.perform(get("/table-schema/my-schemas")
-            .with(oauth2Login().oauth2User(githubUser)))
-        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-        .andExpect(status().isOk())
-        .andExpect(model().attribute("tableSchemas", List.of()))
-        .andExpect(view().name("my-schemas"));
+    @DisplayName("[POST] 테이블 스키마 생성, 변경을 요청하면 정상적으로 수행 후 테이블 스키마 페이지로 리다이렉션한다.")
+    @Test
+    void whenCreatedOrUpdatedTableSchema_ThenRedirectionToTableSchemaPage() throws Exception {
+        //given
+        var githubUser = new GithubUser("test_id", "test_name", "test@email.com");
+        var request = TableSchemaRequestWithMock.create("test_schema",
+            List.of(
+                SchemaFieldRequestWithMock.create("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
+                SchemaFieldRequestWithMock.create("name", MockDataType.NAME, 2, 0, null, null),
+                SchemaFieldRequestWithMock.create("age", MockDataType.NUMBER, 3, 0, null, null)
+            ));
 
-    // then
-    then(tableSchemaService).should().loadTableSchemas("test_id");
-  }
+        willDoNothing().given(tableSchemaService).upsertMySchema(request.toDto(githubUser.id()));
 
+        //when & then
+        mvc.perform(post("/table-schema")
+                .content(encoder.encode(request))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .with(csrf()).with(oauth2Login().oauth2User(githubUser)))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrlTemplate("/table-schema?schemaName={schemaName}",
+                request.getSchemaName()));
 
-  @DisplayName("[GET] 비로그인 사용자 스키마 테이블 목록에서 스키마 이름을 누르면 인증 페이지로 리다이렉션한다.")
-  @Test
-  void whenUnauthenticatedUserEnteredTableSchemaPage_ThenRedirectionToLoginPage() throws Exception {
-    //given
-    //when & then
-    mvc.perform(get("/table-schema/my-schemas"))
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrlPattern("**/oauth2/authorization/github"));
-
-    then(tableSchemaService).shouldHaveNoInteractions();
-  }
+        then(tableSchemaService).should().upsertMySchema(request.toDto(githubUser.id()));
+    }
 
 
-  @DisplayName("[POST] 회원 스키마 삭제 (정상)")
-  @Test
-  void whenAuthUserDeleted_ThenRedirectionToUserTableSchemaView() throws Exception {
-    //given
-    var githubUser = new GithubUser("test_id", "test_name", "test@email.com");
-    String schemaName = "schemaName";
-    //when & then
-    mvc.perform(post("/table-schema/my-schemas/{schemaName}", schemaName)
-            .with(csrf()).with(oauth2Login().oauth2User(githubUser)))
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl("/table-schema/my-schemas"));
-  }
+    @DisplayName("[GET] 회원의 테이블 스키마 목록 페이지를 요청하면 회원의 테이블 스키마 목록 뷰 (정상) 를 반환한다.")
+    @Test
+    void whenAuthUserEnteredAllTableSchemaPage_ThenShowAllTableSchemaView() throws Exception {
+        //given
+        var githubUser = new GithubUser("test_id", "test_name", "test@email.com");
+        //when
+        given(tableSchemaService.loadTableSchemas("test_id")).willReturn(List.of());
+        mvc.perform(get("/table-schema/my-schemas")
+                .with(oauth2Login().oauth2User(githubUser)))
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("tableSchemas", List.of()))
+            .andExpect(view().name("my-schemas"));
+
+        // then
+        then(tableSchemaService).should().loadTableSchemas("test_id");
+    }
 
 
-  @DisplayName("[GET] 테이블 스키마 파일 다운로드 (정상) 후 파일을 반환한다.")
-  @Test
-  void whenTableSchemaDownLoading_ThenReturnResultFile() throws Exception {
-    //given
-    var request = TableSchemaExportRequest.of("test", 60, ExportFileType.JSON,
-        List.of(
-            SchemaFieldRequestWithMock.create("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
-            SchemaFieldRequestWithMock.create("name", MockDataType.NAME, 2, 0, null, null),
-            SchemaFieldRequestWithMock.create("age", MockDataType.NUMBER, 3, 0, null, null)
-        ));
-    var queryParam = encoder.encode(request, false);
+    @DisplayName("[GET] 비로그인 사용자 스키마 테이블 목록에서 스키마 이름을 누르면 인증 페이지로 리다이렉션한다.")
+    @Test
+    void whenUnauthenticatedUserEnteredTableSchemaPage_ThenRedirectionToLoginPage()
+        throws Exception {
+        //given
+        //when & then
+        mvc.perform(get("/table-schema/my-schemas"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrlPattern("**/oauth2/authorization/github"));
 
-    //when & then
-    mvc.perform(get("/table-schema/export?" + queryParam))
-        .andExpect(status().isOk())
-        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
-        .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION,
-            "attachment; filename=table-schema.txt"))
-        .andExpect(content().json(mapper.writeValueAsString(request))); // TODO 수정 필요
-  }
+        then(tableSchemaService).shouldHaveNoInteractions();
+    }
+
+
+    @DisplayName("[POST] 회원 스키마 삭제 (정상)")
+    @Test
+    void whenAuthUserDeleted_ThenRedirectionToUserTableSchemaView() throws Exception {
+        //given
+        var githubUser = new GithubUser("test_id", "test_name", "test@email.com");
+        String schemaName = "schemaName";
+        //when & then
+        mvc.perform(post("/table-schema/my-schemas/{schemaName}", schemaName)
+                .with(csrf()).with(oauth2Login().oauth2User(githubUser)))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/table-schema/my-schemas"));
+    }
+
+
+    @DisplayName("[GET] 테이블 스키마 파일 다운로드 (정상) 후 파일을 반환한다.")
+    @Test
+    void whenTableSchemaDownLoading_ThenReturnResultFile() throws Exception {
+        //given
+        var request = TableSchemaExportRequest.of("test", 60, ExportFileType.JSON,
+            List.of(
+                SchemaFieldRequestWithMock.create("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
+                SchemaFieldRequestWithMock.create("name", MockDataType.NAME, 2, 0, null, null),
+                SchemaFieldRequestWithMock.create("age", MockDataType.NUMBER, 3, 0, null, null)
+            ));
+        var queryParam = encoder.encode(request, false);
+
+        //when & then
+        mvc.perform(get("/table-schema/export?" + queryParam))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+            .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION,
+                "attachment; filename=table-schema.txt"))
+            .andExpect(content().json(mapper.writeValueAsString(request))); // TODO 수정 필요
+    }
 }

--- a/src/test/java/service/TableSchemaServiceTest.java
+++ b/src/test/java/service/TableSchemaServiceTest.java
@@ -100,18 +100,43 @@ class TableSchemaServiceTest {
   }
 
 
-  @DisplayName("회원의 테이블 스키마 생성 정보가 주어지면 새로운 테이블 스키마를 생성한다.")
+  @DisplayName("존재하지 않는 테이블 스키마 생성 정보가 주어지면 새로운 테이블 스키마를 생성한다.")
   @Test
   void whenCreateTableSchemaRequesting_thenCreateNewTableSchema() {
     //given
     TableSchemaDto tableSchemaDto = TableSchemaDto.of("schema1", "test_id", null, Set.of());
+    given(tableSchemaEntityRepository.findByUserIdAndSchemaName(tableSchemaDto.userId(),
+        tableSchemaDto.schemaName()))
+        .willReturn(Optional.empty());
     given(tableSchemaEntityRepository.save(tableSchemaDto.createEntity())).willReturn(null);
 
     //when
-    sut.saveMySchema(tableSchemaDto);
+    sut.upsertMySchema(tableSchemaDto);
 
     //then
+    then(tableSchemaEntityRepository).should()
+        .findByUserIdAndSchemaName(tableSchemaDto.userId(), tableSchemaDto.schemaName());
     then(tableSchemaEntityRepository).should().save(tableSchemaDto.createEntity());
+  }
+
+
+  @DisplayName("존재하는 테이블 스키마 생성 정보가 주어지면 새로운 테이블 스키마를 생성한다.")
+  @Test
+  void whenUpdateTableSchemaRequesting_thenUpdateTableSchema() {
+    //given
+    TableSchemaDto tableSchema = TableSchemaDto.of("schema1", "test_id", null, Set.of());
+    TableSchemaEntity existTableSchema = TableSchemaEntity.of("schema1", "test_id");
+
+    given(tableSchemaEntityRepository.findByUserIdAndSchemaName(tableSchema.userId(),
+        tableSchema.schemaName()))
+        .willReturn(Optional.of(existTableSchema));
+
+    //when
+    sut.upsertMySchema(tableSchema);
+
+    //then
+    then(tableSchemaEntityRepository).should()
+        .findByUserIdAndSchemaName(tableSchema.userId(), tableSchema.schemaName());
   }
 
 


### PR DESCRIPTION
이 작업은 로그인한 사용자가 테이블 스키마를 생성, 수정할 수 있는 서비스 로직을 구현하고 테스트를 진행함  결국에는 하나의 메서드에서 생성, 수정할 수 있도록 구현 하였고 이로 인해 dto, entity 또한 수정됨