### PR TITLE
로직 구현 : 스키마 데이터를 원하는 포맷으로 변환

### DIFF
--- a/src/main/java/com/backend/testdata/service/SchemaExportService.java
+++ b/src/main/java/com/backend/testdata/service/SchemaExportService.java
@@ -1,0 +1,31 @@
+package com.backend.testdata.service;
+
+import com.backend.testdata.domain.TableSchemaEntity;
+import com.backend.testdata.domain.constants.ExportFileType;
+import com.backend.testdata.dto.TableSchemaDto;
+import com.backend.testdata.repository.TableSchemaEntityRepository;
+import com.backend.testdata.service.exporter.MockDataFileExporterContext;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SchemaExportService {
+
+    private final MockDataFileExporterContext mockDataFileExporterContext;
+    private final TableSchemaEntityRepository tableSchemaEntityRepository;
+
+
+    public String export(ExportFileType fileType, TableSchemaDto dto, Integer rowCount) {
+        String userId = dto.userId();
+        if (Objects.nonNull(userId)) {
+            tableSchemaEntityRepository.findByUserIdAndSchemaName(
+                    userId, dto.schemaName())
+                .ifPresent(TableSchemaEntity::markExported);
+        }
+
+        return mockDataFileExporterContext.delegatingExport(fileType, dto, rowCount);
+    }
+
+}

--- a/src/main/java/com/backend/testdata/service/exporter/CSVFileExporter.java
+++ b/src/main/java/com/backend/testdata/service/exporter/CSVFileExporter.java
@@ -1,0 +1,22 @@
+package com.backend.testdata.service.exporter;
+
+import com.backend.testdata.domain.constants.ExportFileType;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class CSVFileExporter extends DelimiterBasedFileExporter {
+
+    private static final String DELIMETER = ",";
+
+
+    @Override
+    public ExportFileType getType() {
+        return ExportFileType.CSV;
+    }
+
+    @Override
+    public String getDelimiter() {
+        return DELIMETER;
+    }
+}

--- a/src/main/java/com/backend/testdata/service/exporter/DelimiterBasedFileExporter.java
+++ b/src/main/java/com/backend/testdata/service/exporter/DelimiterBasedFileExporter.java
@@ -1,0 +1,44 @@
+package com.backend.testdata.service.exporter;
+
+import com.backend.testdata.dto.SchemaFieldDto;
+import com.backend.testdata.dto.TableSchemaDto;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+
+public abstract class DelimiterBasedFileExporter implements MockDataFileExporter {
+
+
+    @Override
+    public String export(TableSchemaDto dto, Integer rowCount) {
+        String delimiter = getDelimiter();
+        StringBuilder sb = new StringBuilder();
+
+        // 헤더
+        sb.append(dto.schemaFields().stream()
+                .sorted(Comparator.comparing(SchemaFieldDto::fieldOrder))
+                .map(SchemaFieldDto::fieldName)
+                .collect(Collectors.joining(delimiter)))
+
+            .append("\n");
+
+        // 데이터
+        IntStream.range(0, rowCount)
+            .forEachOrdered(i -> {
+                sb.append(dto.schemaFields().stream()
+                    .sorted(Comparator.comparing(SchemaFieldDto::fieldOrder))
+                    .map(field -> "가짜 데이터") //TODO 구현필요
+                    .map(value -> Objects.isNull(value) ? "" : value)
+                    .collect(Collectors.joining(delimiter))
+                );
+                sb.append("\n");
+            });
+
+        return sb.toString();
+    }
+
+
+    public abstract String getDelimiter();
+}

--- a/src/main/java/com/backend/testdata/service/exporter/MockDataFileExporter.java
+++ b/src/main/java/com/backend/testdata/service/exporter/MockDataFileExporter.java
@@ -1,0 +1,23 @@
+package com.backend.testdata.service.exporter;
+
+import com.backend.testdata.domain.constants.ExportFileType;
+import com.backend.testdata.dto.TableSchemaDto;
+
+/**
+ * 특정 파일 유형 {@link ExportFileType} 에 맞는 포맷을 제공하는 인터페이스
+ */
+public interface MockDataFileExporter {
+
+    /**
+     * @return 이 구현체가 다루는 파일 유형
+     */
+    ExportFileType getType();
+
+    /**
+     * @param dto      특정 포맷으로 변환될 테이블 스키마
+     * @param rowCount 행 카운트 수
+     * @return 특정 파일 포맷으로 변환되는 문자열 데이터
+     */
+    String export(TableSchemaDto dto, Integer rowCount);
+
+}

--- a/src/main/java/com/backend/testdata/service/exporter/MockDataFileExporterContext.java
+++ b/src/main/java/com/backend/testdata/service/exporter/MockDataFileExporterContext.java
@@ -1,0 +1,28 @@
+package com.backend.testdata.service.exporter;
+
+import com.backend.testdata.domain.constants.ExportFileType;
+import com.backend.testdata.dto.TableSchemaDto;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MockDataFileExporterContext {
+
+    private final Map<ExportFileType, MockDataFileExporter> mockDataFileExporterMap;
+
+
+    public MockDataFileExporterContext(List<MockDataFileExporter> mockDataFileExporters) {
+        this.mockDataFileExporterMap = mockDataFileExporters.stream()
+            .collect(Collectors.toMap(MockDataFileExporter::getType, Function.identity()));
+    }
+
+
+    public String delegatingExport(ExportFileType fileType, TableSchemaDto dto, Integer rowCount) {
+        MockDataFileExporter fileExporter = mockDataFileExporterMap.get(fileType);
+
+        return fileExporter.export(dto, rowCount);
+    }
+}

--- a/src/main/java/com/backend/testdata/service/exporter/TSVFileExporter.java
+++ b/src/main/java/com/backend/testdata/service/exporter/TSVFileExporter.java
@@ -1,0 +1,22 @@
+package com.backend.testdata.service.exporter;
+
+import com.backend.testdata.domain.constants.ExportFileType;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class TSVFileExporter extends DelimiterBasedFileExporter {
+
+    private static final String DELIMETER = "\t";
+
+
+    @Override
+    public ExportFileType getType() {
+        return ExportFileType.TSV;
+    }
+
+    @Override
+    public String getDelimiter() {
+        return DELIMETER;
+    }
+}

--- a/src/test/java/com/backend/testdata/service/SchemaExportServiceTest.java
+++ b/src/test/java/com/backend/testdata/service/SchemaExportServiceTest.java
@@ -1,0 +1,104 @@
+package com.backend.testdata.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.backend.testdata.domain.TableSchemaEntity;
+import com.backend.testdata.domain.constants.ExportFileType;
+import com.backend.testdata.domain.constants.MockDataType;
+import com.backend.testdata.dto.SchemaFieldDto;
+import com.backend.testdata.dto.TableSchemaDto;
+import com.backend.testdata.repository.TableSchemaEntityRepository;
+import com.backend.testdata.service.exporter.MockDataFileExporterContext;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[Service] 스키마 파일 출력 테스트")
+@ExtendWith(MockitoExtension.class)
+class SchemaExportServiceTest {
+
+    @InjectMocks
+    private SchemaExportService sut;
+
+    @Mock
+    private MockDataFileExporterContext exporterContext;
+    @Mock
+    private TableSchemaEntityRepository tableSchemaEntityRepository;
+
+
+    @DisplayName("회원이 출력 파일 유형과 테이블 스키마, 행수를 전달했을 때 엔티티 출력 여부를 체크하고 해당 파일 포맷의 문자열을 반환한다.")
+    @Test
+    void givenExportFileTypeAndTableSchemaAndRowCount_whenAuthUserIsExporting_thenInsertingExportDateAndReturnFormattedString() {
+        //given
+        ExportFileType exportFileType = ExportFileType.CSV;
+        TableSchemaEntity tableSchemaPs = TableSchemaEntity.of("schema1", "test_id");
+        TableSchemaDto dto = TableSchemaDto.of(
+            "schema1",
+            "test_id",
+            null,
+            Set.of(
+                SchemaFieldDto.of("id", MockDataType.STRING, 1, 0, null, null),
+                SchemaFieldDto.of("name", MockDataType.NAME, 2, 0, null, null),
+                SchemaFieldDto.of("age", MockDataType.NUMBER, 3, 0, null, null),
+                SchemaFieldDto.of("car", MockDataType.CAR, 4, 0, null, null),
+                SchemaFieldDto.of("created_at", MockDataType.DATETIME, 5, 0, null, null)
+            )
+        );
+        int rowCount = 10;
+        given(tableSchemaEntityRepository.findByUserIdAndSchemaName(dto.userId(), dto.schemaName()))
+            .willReturn(Optional.of(tableSchemaPs));
+
+        given(exporterContext.delegatingExport(exportFileType, dto, rowCount))
+            .willReturn("CSV DATA");
+
+        //when
+        String result = sut.export(exportFileType, dto, rowCount);
+
+        //then
+        assertThat(result).isEqualTo("CSV DATA");
+        assertThat(tableSchemaPs.isExported()).isTrue();
+        then(tableSchemaEntityRepository).should()
+            .findByUserIdAndSchemaName(dto.userId(), dto.schemaName());
+        then(exporterContext).should().delegatingExport(exportFileType, dto, rowCount);
+    }
+
+
+    @DisplayName("회원이 아닌 출력 파일 유형과 테이블 스키마, 행수를 전달했을 때 엔티티 출력 여부를 체크하지 않아야한다.")
+    @Test
+    void givenExportFileTypeAndTableSchemaAndRowCount_whenUnAuthUserIsExporting_thenDoesNotRetrieveTableSchema() {
+        //given
+        ExportFileType exportFileType = ExportFileType.CSV;
+        TableSchemaDto dto = TableSchemaDto.of(
+            "schema1",
+            null,
+            null,
+            Set.of(
+                SchemaFieldDto.of("id", MockDataType.STRING, 1, 0, null, null),
+                SchemaFieldDto.of("name", MockDataType.NAME, 2, 0, null, null),
+                SchemaFieldDto.of("age", MockDataType.NUMBER, 3, 0, null, null),
+                SchemaFieldDto.of("car", MockDataType.CAR, 4, 0, null, null),
+                SchemaFieldDto.of("created_at", MockDataType.DATETIME, 5, 0, null, null)
+            )
+        );
+        int rowCount = 10;
+
+        given(exporterContext.delegatingExport(exportFileType, dto, rowCount))
+            .willReturn("CSV DATA");
+
+        //when
+        String result = sut.export(exportFileType, dto, rowCount);
+
+        //then
+        assertThat(result).isEqualTo("CSV DATA");
+        then(tableSchemaEntityRepository).shouldHaveNoInteractions();
+        then(exporterContext).should().delegatingExport(exportFileType, dto, rowCount);
+    }
+
+}

--- a/src/test/java/com/backend/testdata/service/exporter/CSVFileExporterTest.java
+++ b/src/test/java/com/backend/testdata/service/exporter/CSVFileExporterTest.java
@@ -1,0 +1,47 @@
+package com.backend.testdata.service.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.backend.testdata.domain.constants.MockDataType;
+import com.backend.testdata.dto.SchemaFieldDto;
+import com.backend.testdata.dto.TableSchemaDto;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[Logic] CSV 파일 출력기 테스트")
+class CSVFileExporterTest {
+
+
+    private DelimiterBasedFileExporter sut = new CSVFileExporter();
+
+
+    @DisplayName("테이블 스키마와 행수가 주어지면 CSV 형식의 문자열을 생성한다.")
+    @Test
+    void givenTableSchemaAndRowCount_whenExporting_thenReturnCSVFormattedString() {
+        //given
+        TableSchemaDto tableSchema = TableSchemaDto.of(
+            "schema1",
+            "test_id",
+            null,
+            Set.of(
+                SchemaFieldDto.of("id", MockDataType.STRING, 1, 0, null, null),
+                SchemaFieldDto.of("name", MockDataType.NAME, 2, 0, null, null),
+                SchemaFieldDto.of("age", MockDataType.NUMBER, 3, 0, null, null),
+                SchemaFieldDto.of("car", MockDataType.CAR, 4, 0, null, null),
+                SchemaFieldDto.of("created_at", MockDataType.DATETIME, 5, 0, null, null)
+            )
+        );
+        int rowCount = 10;
+
+        //when
+        String result = sut.export(tableSchema, rowCount);
+
+        //then
+        System.out.println(result);
+        assertThat(result).startsWith("id,name,age,car,created_at");
+        assertThat(result).hasLineCount(11);
+
+    }
+
+}

--- a/src/test/java/com/backend/testdata/service/exporter/MockDataFileExporterContextTest.java
+++ b/src/test/java/com/backend/testdata/service/exporter/MockDataFileExporterContextTest.java
@@ -1,0 +1,49 @@
+package com.backend.testdata.service.exporter;
+
+import com.backend.testdata.domain.constants.ExportFileType;
+import com.backend.testdata.domain.constants.MockDataType;
+import com.backend.testdata.dto.SchemaFieldDto;
+import com.backend.testdata.dto.TableSchemaDto;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DisplayName("[IntergrationTest] 파일 출력기 컨텍스트 테스트")
+@SpringBootTest
+class MockDataFileExporterContextTest {
+
+    @Autowired
+    private MockDataFileExporterContext sut;
+
+
+    @DisplayName("ExportFileType, 테이블 스키마, 행수가 주어지면 이 형식에 맞게 문자열을 반환한다.")
+    @Test
+    void givenExportFileTypeAndTableSchemaAndRowCount_whenExporting_thenReturnFormattedString() {
+        //given
+        ExportFileType exportFileType = ExportFileType.TSV;
+        TableSchemaDto tableSchema = TableSchemaDto.of(
+            "schema1",
+            "test_id",
+            null,
+            Set.of(
+                SchemaFieldDto.of("id", MockDataType.STRING, 1, 0, null, null),
+                SchemaFieldDto.of("name", MockDataType.NAME, 2, 0, null, null),
+                SchemaFieldDto.of("age", MockDataType.NUMBER, 3, 0, null, null),
+                SchemaFieldDto.of("car", MockDataType.CAR, 4, 0, null, null),
+                SchemaFieldDto.of("created_at", MockDataType.DATETIME, 5, 0, null, null)
+            )
+        );
+        int rowCount = 10;
+
+        //when
+        String result = sut.delegatingExport(exportFileType, tableSchema, rowCount);
+
+        //then
+        System.out.println(result);
+    }
+
+}

--- a/src/test/java/com/backend/testdata/service/exporter/TSVFileExporterTest.java
+++ b/src/test/java/com/backend/testdata/service/exporter/TSVFileExporterTest.java
@@ -1,0 +1,47 @@
+package com.backend.testdata.service.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.backend.testdata.domain.constants.MockDataType;
+import com.backend.testdata.dto.SchemaFieldDto;
+import com.backend.testdata.dto.TableSchemaDto;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[Logic] TSV 파일 출력기 테스트")
+class TSVFileExporterTest {
+
+
+    private DelimiterBasedFileExporter sut = new TSVFileExporter();
+
+
+    @DisplayName("테이블 스키마와 행수가 주어지면 CSV 형식의 문자열을 생성한다.")
+    @Test
+    void givenTableSchemaAndRowCount_whenExporting_thenReturnCSVFormattedString() {
+        //given
+        TableSchemaDto tableSchema = TableSchemaDto.of(
+            "schema1",
+            "test_id",
+            null,
+            Set.of(
+                SchemaFieldDto.of("id", MockDataType.STRING, 1, 0, null, null),
+                SchemaFieldDto.of("name", MockDataType.NAME, 2, 0, null, null),
+                SchemaFieldDto.of("age", MockDataType.NUMBER, 3, 0, null, null),
+                SchemaFieldDto.of("car", MockDataType.CAR, 4, 0, null, null),
+                SchemaFieldDto.of("created_at", MockDataType.DATETIME, 5, 0, null, null)
+            )
+        );
+        int rowCount = 10;
+
+        //when
+        String result = sut.export(tableSchema, rowCount);
+
+        //then
+        System.out.println(result);
+        assertThat(result).startsWith("id\tname\tage\tcar\tcreated_at");
+        assertThat(result).hasLineCount(11);
+
+    }
+
+}


### PR DESCRIPTION
이 작업은 테이블 스키마를 원하는 파일 포맷 형식으로 변환하는 기능을 구현하고 테스트를 진행함 현재 파일 형식 변환기는 CSV, TSV 까지 구현된 작업임

This closes #50 